### PR TITLE
Update MessageHandler.cpp

### DIFF
--- a/backend/scalestore/rdma/MessageHandler.cpp
+++ b/backend/scalestore/rdma/MessageHandler.cpp
@@ -39,7 +39,7 @@ void MessageHandler::init() {
    // -------------------------------------------------------------------------------------
    size_t numConnections = (FLAGS_worker) * (FLAGS_nodes - 1);
    connectedClients = numConnections;
-   while (cm.getNumberIncomingConnections() != (numConnections))
+   while (cm.getNumberIncomingConnections() < (numConnections))
       ;  // block until client is connected
    // -------------------------------------------------------------------------------------
    std::cout << "Number connections " << numConnections << std::endl;


### PR DESCRIPTION
This waiting predicate can result in program blocking,  if the message handler threads shared CPU cores with worker threads. This modification can solve this problem. (cm.getNumberIncomingConnections() != numConnnection) -->(cm.getNumberIncomingConnections() > numConnnection)